### PR TITLE
Handle GPO Comment gracefully when Central Store is on D:\SYSVOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The following optional variables can be set to control the GPO config;
     * `uppercase,lowercase,digits`
     * `uppercase,lowercase,digits,symbols` *default*
 * `opt_laps_password_policy_length`: The length of the password to generate (default: `14`)
+* `opt_laps_gpo_comment_path`: The path for GPO Comment (default: `opt_laps_gpo_comment_path: D:\SYSVOL\domain\Policies\{{ '{' }}{{ pri_laps_gpo.id }}{{ '}' }}\Machine\comment.cmtx`
 
 ### Output Variables
 
@@ -126,8 +127,19 @@ None
   - role: jborean93.win_laps
     man_laps_ou_containers:
     - OU=Workstations,DC=domain,DC=local
-    opt_laps_install_server; True
+    opt_laps_install_server: True
     opt_laps_configure_gpo: True
+    
+- name: install the LAPS server and create a GPO when SYSVOL is on D:\
+  hosts: windows
+  gather_facts: no
+  roles:
+  - role: jborean93.win_laps
+    man_laps_ou_containers:
+    - OU=Workstations,DC=domain,DC=local
+    opt_laps_install_server: True
+    opt_laps_configure_gpo: True
+    opt_laps_gpo_comment_path: D:\SYSVOL\domain\Policies\{{ '{' }}{{ pri_laps_gpo.id }}{{ '}' }}\Machine\comment.cmtx
 ```
 
 Once the role has been run the `win_ad_dacl` module, and others, will be

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The following optional variables can be set to control the GPO config;
     * `uppercase,lowercase,digits`
     * `uppercase,lowercase,digits,symbols` *default*
 * `opt_laps_password_policy_length`: The length of the password to generate (default: `14`)
-* `opt_laps_gpo_comment_path`: The path for GPO Comment (default: `opt_laps_gpo_comment_path: D:\SYSVOL\domain\Policies\{{ '{' }}{{ pri_laps_gpo.id }}{{ '}' }}\Machine\comment.cmtx`
+* `opt_laps_gpo_comment_path`: The path for GPO Comment (default: `C:\SYSVOL\domain\Policies\{{ '{' }}{{ pri_laps_gpo.id }}{{ '}' }}\Machine\comment.cmtx`
 
 ### Output Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,4 @@ opt_laps_gpo_name: ansible-laps
 opt_laps_password_policy_complexity: uppercase,lowercase,digits,symbols
 opt_laps_password_policy_length: 14
 opt_laps_password_policy_age: 30
+opt_laps_gpo_comment_path: C:\Windows\SYSVOL\domain\Policies\{{ '{' }}{{ pri_laps_gpo.id }}{{ '}' }}\Machine\comment.cmtx

--- a/tasks/gpo.yml
+++ b/tasks/gpo.yml
@@ -81,7 +81,7 @@
 - name: create comment file for GPO
   win_copy:
     src: comment.cmtx
-    dest: C:\Windows\SYSVOL\domain\Policies\{{ '{' }}{{ pri_laps_gpo.id }}{{ '}' }}\Machine\comment.cmtx
+    dest: '{{ opt_laps_gpo_comment_path }}'
   when: not ansible_check_mode
 
 - name: ensure GPO is linked and enforced

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,7 @@ pri_laps_gpo_reg_path: HKLM\Software\Policies\Microsoft Services\AdmPwd
 pri_laps_install_urls:
   AMD64: https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x64.msi
   X86: https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.x86.msi
+  ARM64: https://download.microsoft.com/download/C/7/A/C7AAD914-A8A6-4904-88A1-29E657445D03/LAPS.ARM64.msi
 
 # converts opt_laps_password_policy_complexity to the value expected by GPO
 pri_laps_password_policy_complexity:


### PR DESCRIPTION
* Update README
* Update `defaults/main.yml` to have a new variable `opt_laps_gpo_comment_path`
* Update `tasks/gpo.yml` to utilize variable for GPO Comment destination

Can't think of a way offhand to deal with relocating `AdmPwd.admx` to a Central Store on D:\SYSVOL