### PR TITLE
Syntax fix for documentation linting issue

### DIFF
--- a/library/win_ad_dacl.py
+++ b/library/win_ad_dacl.py
@@ -50,7 +50,7 @@ options:
         - Descendents
         - None
         - SelfAndChildren
-        required; True
+        required: True
         type: str
       inherited_object_type:
         description:


### PR DESCRIPTION
Minor linting issue, line 53 (semicolon instead of colon)